### PR TITLE
Provision calculation

### DIFF
--- a/app/Http/Resources/TmsOrderEditResource.php
+++ b/app/Http/Resources/TmsOrderEditResource.php
@@ -63,7 +63,6 @@ class TmsOrderEditResource extends JsonResource
      * The other one will have data. We place the found data under the key 'details' in the
      * response.
      *
-     * @return void
      */
     private function setDetails()
     {
@@ -87,7 +86,22 @@ class TmsOrderEditResource extends JsonResource
      */
     private function calculateProvisionEur(): float
     {
-        return $this->provision * $this->exchange_rate;
+        //Get the provision percentage from tms_orders table.
+        $provisionPercentage = $this->provision;
+
+        //Get all data from pamyra_orders or native_orders table (one will have data, the other will be null)
+        $pamyraOrNativeOrder = $this->setDetails();
+
+        //Get the price_net from pamyra_orders or native_orders table.
+        $priceNet = $pamyraOrNativeOrder->price_net;
+
+        //Calculate the provision in EUR.
+        $provisionValueInEur = $priceNet * $provisionPercentage / 100;
+
+        //Round to 2 decimal places.
+        $provisionValueInEur = round($provisionValueInEur, 2);
+
+        return $provisionValueInEur;
     }
     
 }

--- a/app/Http/Resources/TmsOrderEditResource.php
+++ b/app/Http/Resources/TmsOrderEditResource.php
@@ -3,6 +3,8 @@
 namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
+use App\Models\TmsNativeOrder;
+use App\Models\TmsPamyraOrder;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
@@ -62,9 +64,10 @@ class TmsOrderEditResource extends JsonResource
      * controller we call pamyraOrder() and nativeOrder() relationships. One of them will be null.
      * The other one will have data. We place the found data under the key 'details' in the
      * response.
-     *
+     * 
+     * @return TmsPamyraOrder | TmsNativeOrder
      */
-    private function setDetails()
+    private function setDetails(): TmsPamyraOrder | TmsNativeOrder
     {
 
         $pamyraOrder = $this->pamyraOrder ?? null;

--- a/app/Http/Resources/TmsOrderEditResource.php
+++ b/app/Http/Resources/TmsOrderEditResource.php
@@ -26,6 +26,7 @@ class TmsOrderEditResource extends JsonResource
             'status' => $this->status,
             'customer_reference' => $this->customer_reference,
             'provision' => $this->provision,
+            'provisionEur' => $this->calculateProvisionEur(),
             'order_edited_events' => $this->order_edited_events,
             'currency' => $this->currency,
             'order_number' => $this->order_number,
@@ -78,6 +79,17 @@ class TmsOrderEditResource extends JsonResource
             return $nativeOrder;
         }
     }
+
+    /**
+     * Calculate the provision in EUR.
+     *
+     * @return float
+     */
+    private function calculateProvisionEur(): float
+    {
+        return $this->provision * $this->exchange_rate;
+    }
+    
 }
 
 

--- a/database/factories/TmsProvisionFactory.php
+++ b/database/factories/TmsProvisionFactory.php
@@ -23,9 +23,9 @@ class TmsProvisionFactory extends Factory
              * So, the number 1 here is realistic.
              */
             'partner_id' => 1,
-            'value' => $this->faker->randomFloat(2, 0, 10),//Example: 1.5%,
-            'valid_from' => $date = $this->faker->date(),
-            'valid_to' => $this->faker->dateTimeBetween($date, '+30 days')->format('Y-m-d'), 
+            'value' => 6,//Pamyra does 6% provision
+            'valid_from' => '2023-01-01 00:00:00',
+            'valid_to' => '2025-12-31 23:59:59',
         ];
     }
 }

--- a/database/factories/TmsProvisionFactory.php
+++ b/database/factories/TmsProvisionFactory.php
@@ -17,11 +17,6 @@ class TmsProvisionFactory extends Factory
     public function definition(): array
     {
         return [
-            
-            /**
-             * There will be 3 provisions faked. These 3 provisions can easily belong to one partner.
-             * So, the number 1 here is realistic.
-             */
             'partner_id' => 1,
             'value' => 6,//Pamyra does 6% provision
             'valid_from' => '2023-01-01 00:00:00',


### PR DESCRIPTION
Provision calculation for order edit page: send EUR and not % to FE. Use the provision from the provisions table to calculate.