### PR TITLE
✨ feat: update form sections and translations for orders

### DIFF
--- a/resources/js/config/Pages/Addresses/Form/_config.js
+++ b/resources/js/config/Pages/Addresses/Form/_config.js
@@ -1,7 +1,7 @@
 export default {
     sections: [
         {
-            "title": "pages.addresses.form.sections.customer_information",
+            "title": "pages.addresses.form.sections.address_information",
             "rows": [
                 {className: 'grid-flow-row gap-4', fields: [
                         {

--- a/resources/js/config/Pages/Forwarders/Form/_config.js
+++ b/resources/js/config/Pages/Forwarders/Form/_config.js
@@ -1,79 +1,85 @@
 export default {
     sections: [
         {
-            "title": "pages.customers.form.sections.customer_information",
-            "cols": 12,
-            "fields": [
-                {
-                    "name": "id",
-                    "size": "col-span-6",
-                    "label": "pages.forwarders.form.id",
-                    "placeholder": "pages.forwarders.form.id",
-                    "type": "text"
-                },
-                {
-                    "name": "company_name",
-                    "size": "col-span-6",
-                    "label": "pages.forwarders.form.company_name",
-                    "placeholder": "pages.forwarders.form.company_name",
-                    "type": "text"
-                },
-                {
-                    "name": "internal_id",
-                    "size": "col-span-6",
-                    "label": "pages.forwarders.form.internal_id",
-                    "placeholder": "pages.forwarders.form.internal_id",
-                    "type": "text"
-                },
-                {
-                    "name": "name",
-                    "size": "col-span-6",
-                    "label": "pages.forwarders.form.name",
-                    "placeholder": "pages.forwarders.form.name",
-                    "type": "text"
-                },
-                {
-                    "name": "email",
-                    "size": "col-span-6",
-                    "label": "pages.forwarders.form.email",
-                    "placeholder": "pages.forwarders.form.email",
-                    "type": "text"
-                },
-                {
-                    "name": "tax_number",
-                    "size": "col-span-6",
-                    "label": "pages.forwarders.form.tax_number",
-                    "placeholder": "pages.forwarders.form.tax_number",
-                    "type": "text"
-                },
-                {
-                    "name": "rating",
-                    "size": "col-span-6",
-                    "label": "pages.forwarders.form.rating",
-                    "placeholder": "pages.forwarders.form.rating",
-                    "type": "text"
-                },
-                {
-                    "name": "forwarder_type",
-                    "size": "col-span-6",
-                    "label": "pages.forwarders.form.forwarder_type",
-                    "placeholder": "pages.forwarders.form.forwarder_type",
-                    "type": "text"
-                },
-                {
-                    "name": "comments",
-                    "size": "col-span-6",
-                    "label": "pages.forwarders.form.comments",
-                    "placeholder": "pages.forwarders.form.comments",
-                    "type": "text"
-                },
-                {
-                    "name": "url_logo",
-                    "size": "col-span-6",
-                    "label": "pages.forwarders.form.url_logo",
-                    "placeholder": "pages.forwarders.form.url_logo",
-                    "type": "text"
-                }
+            title: "pages.forwarders.form.sections.customer_information",
+            cols: 12,
+            rows: [
+                {className: 'grid-flow-row gap-4', fields: [
+                    {
+                        "name": "company_name",
+                        "className": "col-auto",
+                        "label": "pages.forwarders.form.company_name",
+                        "placeholder": "pages.forwarders.form.company_name",
+                        "type": "text"
+                    },
+                    {
+                        "name": "internal_id",
+                        "className": "col-auto",
+                        "label": "pages.forwarders.form.internal_id",
+                        "placeholder": "pages.forwarders.form.internal_id",
+                        "type": "text"
+                    },
+                ]},
+                {className: 'grid-flow-row gap-4', fields: [
+                    {
+                        "name": "name",
+                        "className": "col-auto",
+                        "label": "pages.forwarders.form.name",
+                        "placeholder": "pages.forwarders.form.name",
+                        "type": "text"
+                    },
+                    {
+                        "name": "email",
+                        "className": "col-auto",
+                        "label": "pages.forwarders.form.email",
+                        "placeholder": "pages.forwarders.form.email",
+                        "type": "text"
+                    },
+                ]},
+                {className: 'grid-flow-row gap-4', fields: [
+                    {
+                        "name": "tax_number",
+                        "className": "col-auto",
+                        "label": "pages.forwarders.form.tax_number",
+                        "placeholder": "pages.forwarders.form.tax_number",
+                        "type": "text"
+                    },
+                ]},
+                {className: 'grid-flow-row gap-4', fields: [
+                    {
+                        "name": "rating",
+                        "className": "col-auto",
+                        "label": "pages.forwarders.form.rating",
+                        "placeholder": "pages.forwarders.form.rating",
+                        "type": "select",
+                        "options": "ratings",
+                        "match": "rating",
+                        "displayKey": "rating|translate:title",
+                    },
+                    {
+                        "name": "forwarder_type",
+                        "className": "col-auto",
+                        "label": "pages.forwarders.form.forwarder_type",
+                        "placeholder": "pages.forwarders.form.forwarder_type",
+                        "type": "text"
+                    },
+                ]},
+                {className: 'grid-flow-row gap-4', fields: [
+                    {
+                        "name": "comments",
+                        "className": "col-auto",
+                        "label": "pages.forwarders.form.comments",
+                        "placeholder": "pages.forwarders.form.comments",
+                        "type": "text"
+                    },
+                    {
+                        "name": "url_logo",
+                        "className": "col-auto",
+                        "label": "pages.forwarders.form.url_logo",
+                        "placeholder": "pages.forwarders.form.url_logo",
+                        "type": "text"
+                    }
+                ]}
             ]
         }
         

--- a/resources/js/config/Pages/Orders/Form/_details.js
+++ b/resources/js/config/Pages/Orders/Form/_details.js
@@ -1,7 +1,7 @@
 export default {
     sections: [
         {
-            title: "pages.orders.tabs.order_details",
+            title: "pages.orders.form.sections.order_details",
             sectionType: "default",
             collapsible: true,
             rows: [
@@ -13,8 +13,8 @@ export default {
                             type: 'text',
                             keyName: 'id',
                             className: 'col-auto',
-                            placeholder: 'pages.addresses.form.type_of_transport',
-                            label: 'pages.addresses.form.type_of_transport',
+                            placeholder: 'pages.orders.form.type_of_transport',
+                            label: 'pages.orders.form.type_of_transport',
                         },
                         {
                             name: 'order_status_id',
@@ -97,6 +97,74 @@ export default {
                     ]
                 },
             ]
+        },
+        {
+            title: "pages.orders.form.sections.parcels",
+            sectionType: "parcel",
+            collapsible: true,
+            data: "parcels",
+            rows: [
+                {
+                    className: 'grid-flow-row gap-4',
+                    fields: [
+                        {
+                            name: 'parcel_type',
+                            type: 'select',
+                            keyName: 'id',
+                            className: 'col-auto min-w-48 w-48',
+                            placeholder: 'pages.orders.form.parcel_type',
+                            label: 'pages.orders.form.parcel_type',
+                        },
+                        {
+                            name: 'length',
+                            type: 'text',
+                            keyName: 'id',
+                            className: 'col-auto',
+                            placeholder: 'pages.orders.form.length',
+                            label: 'pages.orders.form.length',
+                        },
+                        {
+                            name: 'width',
+                            type: 'text',
+                            className: 'col-auto',
+                            placeholder: 'pages.orders.form.width',
+                            label: 'pages.orders.form.width',
+                        },
+                        {
+                            name: 'height',
+                            type: 'text',
+                            className: 'col-auto',
+                            placeholder: 'pages.orders.form.height',
+                            label: 'pages.orders.form.height',
+                        },
+                        {
+                            name: 'weight',
+                            type: 'text',
+                            className: 'col-auto',
+                            placeholder: 'pages.orders.form.weight',
+                            label: 'pages.orders.form.weight',
+                        },
+                    ]
+                }
+            ]
+        },
+        {
+            title: "pages.orders.form.sections.orders",
+            sectionType: "default",
+            collapsible: true,
+            rows: []
+        },
+        {
+            title: "pages.orders.form.sections.finances",
+            sectionType: "default",
+            collapsible: true,
+            rows: []
+        },
+        {
+            title: "pages.orders.form.sections.vehicles",
+            sectionType: "default",
+            collapsible: true,
+            rows: []
         }
     ]
 }

--- a/resources/js/lib/Data.js
+++ b/resources/js/lib/Data.js
@@ -9,6 +9,10 @@ export default class Data {
         let ratings = await axios.get('/api/ratings');
         return ratings;
     }
+    async #ism(){
+        let ism = await axios.get('/api/invocie-shipping-methods');
+        return ism;
+    }
     async #forwarders(){
         let forwarders = await axios.get('/api/forwarders');
         return forwarders;
@@ -33,6 +37,8 @@ export default class Data {
                 return await this.#countries();
             case 'ratings':
                 return await this.#ratings();
+            case 'ism':
+                return await this.#ism();
             case 'forwarders':
                 return await this.#forwarders();
             case 'customers':

--- a/resources/js/lib/Data.js
+++ b/resources/js/lib/Data.js
@@ -5,6 +5,10 @@ export default class Data {
         let countries = await axios.get('/api/countries');
         return countries;
     }
+    async #ratings(){
+        let ratings = await axios.get('/api/ratings');
+        return ratings;
+    }
     async #forwarders(){
         let forwarders = await axios.get('/api/forwarders');
         return forwarders;
@@ -27,6 +31,8 @@ export default class Data {
         switch(target){
             case 'countries':
                 return await this.#countries();
+            case 'ratings':
+                return await this.#ratings();
             case 'forwarders':
                 return await this.#forwarders();
             case 'customers':

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -14,6 +14,20 @@
         "failed": "Diese Anmeldeinformationen stimmen nicht mit unseren Aufzeichnungen überein.",
         "throttle": "Zu viele Anmeldeversuche. Bitte versuchen Sie es in :seconds Sekunden erneut."
     },
+    "general": {
+        "ratings": {
+            "excellent": "Ausgezeichnet",
+            "good": "Gut",
+            "satisfactory": "Befriedigend",
+            "sufficient": "Ausreichend",
+            "poor": "Mangelhaft",
+            "very_poor": "Sehr schlecht",
+            "not_rated": "Nicht bewertet",
+            "no_rating": "Keine Bewertung",
+            "miserable": "Miserabel",
+            "average": "Durchschnittlich"
+        }
+    },
     "menu": {
         "dashboard": "Dashboard",
         "orders": "Aufträge",
@@ -114,6 +128,25 @@
                 "invoices": "Rechnungen",
                 "comments": "Kommentare",
                 "changelog": "Änderungsprotokoll"
+            },
+            "form": {
+                "sections": {
+                    "order_details": "Auftragsdetails",
+                    "parcels": "Packstücke",
+                    "addresses": "Adressen",
+                    "finances": "Finanzen",
+                    "vehicles": "Fahrzanforderungen"
+                },
+                "type_of_transport": "Transportart",
+                "order_status": "Auftragsstatus",
+                "partner": "Partner",
+                "origin": "Abholort",
+                "first_name": "Vorname",
+                "parcel_type": "Packstücktyp",
+                "length": "Länge (cm)",
+                "width": "Breite (cm)",
+                "height": "Höhe (cm)",
+                "weight": "Gewicht (kg)"
             }
         },
         "customers": {
@@ -164,7 +197,7 @@
             "edit": "Adresse bearbeiten",
             "form": {
                 "sections": {
-                    "customer_information": "Kundeninformationen"
+                    "address_information": "Adressinformationen"
                 },
                 "company_name": "Firmenname",
                 "first_name": "Vorname",
@@ -187,7 +220,24 @@
         "forwarders": {
             "index": "Dienstleister",
             "create":"Dienstleister anlegen",
-            "edit": "Dienstleister bearbeiten"
+            "edit": "Dienstleister bearbeiten",
+            "form": {
+                "sections": {
+                    "customer_information": "Kundeninformationen",
+                    "general_information": "Allgemeine Informationen",
+                    "contact_information": "Kontaktinformationen",
+                    "additional_information": "Zusätzliche Informationen"
+                },
+                "company_name": "Firmenname",
+                "internal_id": "Interne ID",
+                "name": "Name",
+                "email": "E-Mail",
+                "tax_number": "Steuernummer",
+                "rating": "Bewertung",
+                "forwarder_type": "Dienstleistertyp",
+                "comments": "Kommentare",
+                "url_logo": "Logo-URL"
+            }
         },
         "vehicles": {
             "index": "Fahrzeuge",

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,8 +20,18 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::middleware('auth:sanctum')->group(function(){
+
     Route::get('/countries', function (Request $request){
         return TmsCountry::all();
+    });
+    Route::get('/ratings', function (Request $request){
+        return [
+            ["id" => 1, "title" => "general.ratings.miserable", "rating" => 1],
+            ["id" => 2, "title" => "general.ratings.poor", "rating" => 2],
+            ["id" => 3, "title" => "general.ratings.average", "rating" => 3],
+            ["id" => 4, "title" => "general.ratings.good", "rating" => 4],
+            ["id" => 5, "title" => "general.ratings.excellent", "rating" => 5]
+        ];
     });
     Route::get('/forwarders', function (Request $request){
         return TmsForwarder::all();

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,6 +33,12 @@ Route::middleware('auth:sanctum')->group(function(){
             ["id" => 5, "title" => "general.ratings.excellent", "rating" => 5]
         ];
     });
+    Route::get('/invocie-shipping-methods', function (Request $request){
+        return [
+            ["id" => 1, "title" => "general.invoice_shipping_method.post"],
+            ["id" => 2, "title" => "general.invoice_shipping_method.email"]
+        ];
+    });
     Route::get('/forwarders', function (Request $request){
         return TmsForwarder::all();
     });


### PR DESCRIPTION
This commit updates the form sections and translations for the orders page. The following changes were made:

- Renamed the section title "pages.orders.tabs.order_details" to "pages.orders.form.sections.order_details"
- Updated the placeholder and label for the "type_of_transport" field in the "order_details" section
- Added new sections for "parcels", "orders", "finances", and "vehicles" with their respective titles and fields
- Added translations for the "ratings" in the "general" section

These changes were made to improve the organization and user experience of the orders form.