### PR TITLE
🔨 chore: update form field types and parsing of values in customer form

### DIFF
--- a/resources/js/Stores/customerStore.js
+++ b/resources/js/Stores/customerStore.js
@@ -6,6 +6,9 @@ export const store = defineStore('address', {
         records: []
     }),
 
+    getters: {
+        
+    },
     actions: {
         set(records) {
             this.records = records;
@@ -20,9 +23,25 @@ export const store = defineStore('address', {
             return this.record;
         },
         store(){
+            this.record.rating = parseInt(this.record.rating);
+            this.record.payment_time = parseInt(this.record.payment_time);
+            this.record.customer_type = parseInt(this.record.customer_type);
+            this.record.easy_bill_customer_id = parseInt(this.record.easy_bill_customer_id);
+            this.record.invoice_dispatch = parseInt(this.record.invoice_dispatch);
+            this.record.invoice_shipping_method = parseInt(this.record.invoice_shipping_method);
+            this.record.payment_method_options_to_offer = [];
+
             router.post(route("customers.store"), this.record);
         },
         save(){
+            this.record.rating = parseInt(this.record.rating);
+            this.record.payment_time = parseInt(this.record.payment_time);
+            this.record.customer_type = parseInt(this.record.customer_type);
+            this.record.easy_bill_customer_id = parseInt(this.record.easy_bill_customer_id);
+            this.record.invoice_dispatch = parseInt(this.record.invoice_dispatch);
+            this.record.invoice_shipping_method = parseInt(this.record.invoice_shipping_method);
+            this.record.payment_method_options_to_offer = [];
+
             router.put(route("customers.update", this.record.id ), this.record);
         },
         update( field, value ){

--- a/resources/js/config/Pages/Customers/Form/_config.js
+++ b/resources/js/config/Pages/Customers/Form/_config.js
@@ -207,7 +207,11 @@ export default {
                         className: "col-auto",
                         "label": "pages.customers.form.invoice_shipping_method", 
                         "placeholder": "pages.customers.form.invoice_shipping_method", 
-                        "type": "text"
+                        "type": "select",
+                        "options": "ism",
+                        "displayKey": "title",
+                        "match": "id",
+
                     },
                     {
                         "name": "payment_method",


### PR DESCRIPTION
The form field for "invoice_shipping_method" has been changed from a text input to a select dropdown. The options for the select dropdown are fetched from the "ism" object. The selected option is now stored as an integer value.

Additionally, when saving or updating a customer record, the values for "rating", "payment_time", "customer_type", "easy_bill_customer_id", "invoice_dispatch", and "invoice_shipping_method" are now parsed as integers before sending the request. The "payment_method_options_to_offer" field is also set to an empty array.