### PR TITLE
🔨 chore: add customer types options to customer form select field

### DIFF
--- a/resources/js/config/Pages/Customers/Form/_config.js
+++ b/resources/js/config/Pages/Customers/Form/_config.js
@@ -193,7 +193,10 @@ export default {
                         className: "col-auto",
                         "label": "pages.customers.form.customer_type", 
                         "placeholder": "pages.customers.form.customer_type", 
-                        "type": "text"
+                        "type": "select",
+                        "options": "customertypes",
+                        "displayKey": "name",
+                        "match": "id",
                     },
                     {
                         "name": "invoice_dispatch",

--- a/resources/js/lib/Data.js
+++ b/resources/js/lib/Data.js
@@ -13,6 +13,10 @@ export default class Data {
         let ism = await axios.get('/api/invocie-shipping-methods');
         return ism;
     }
+    async #customertypes(){
+        let ct = await axios.get('/api/customer-types');
+        return ct;
+    }
     async #forwarders(){
         let forwarders = await axios.get('/api/forwarders');
         return forwarders;
@@ -39,6 +43,8 @@ export default class Data {
                 return await this.#ratings();
             case 'ism':
                 return await this.#ism();
+            case 'customertypes':
+                return await this.#customertypes();
             case 'forwarders':
                 return await this.#forwarders();
             case 'customers':

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,6 +33,12 @@ Route::middleware('auth:sanctum')->group(function(){
             ["id" => 5, "title" => "general.ratings.excellent", "rating" => 5]
         ];
     });
+    Route::get('/customer-types', function (Request $request){
+        return [
+            ["id" => 1, "name" => "general.customer-types.business"],
+            ["id" => 2, "name" => "general.customer-types.private"],
+        ];
+    });
     Route::get('/invocie-shipping-methods', function (Request $request){
         return [
             ["id" => 1, "title" => "general.invoice_shipping_method.post"],


### PR DESCRIPTION
The customer form select field for customer types has been updated to include options fetched from the `/api/customer-types` endpoint. The options are now displayed using the `name` property and the `id` property is used for matching.