### PR TITLE
🔨 chore: refactor order details form layout

### DIFF
--- a/resources/js/Components/Editors/AddressesEditor.vue
+++ b/resources/js/Components/Editors/AddressesEditor.vue
@@ -12,6 +12,6 @@ const props = defineProps({
 </script>
 <template>
     <div v-for="address in addresses" class="mt-4">
-        
+        IN PROGRESS -> Finished Do. 29.02.2024
     </div>
 </template>

--- a/resources/js/Components/Form.vue
+++ b/resources/js/Components/Form.vue
@@ -28,59 +28,63 @@ const data = ref(props.useData ? props.content : {});
 
 </script>
 <template>
-    <section v-for="section in form.sections" class="grid col-span-12 gap-4">
-        <h2 v-if="section.title" class="mt-8 mb-3 font-bold text-[16px]">{{ $t(section.title) }}</h2>
-        <div v-if="!section.sectionType || section.sectionType ==='default'" v-for="row, index in section.rows" :key="index" class="grid grid-flow-col" :class="row.className">
-            <div v-for="field in row.fields" :key="field.name" :class="field.className">
-                <InputField 
-                    v-if="field.type === 'input'" 
-                    :field="field" 
-                    :store="store" 
-                    :data="useData ? (field.subfield ? data[field.name] :  data) : {}" 
-                    />
-                    
-                <CheckboxField 
-                    v-else-if="field.type === 'check'" 
-                    :field="field" 
-                    :store="store" 
-                    :data="useData ? data : {}" 
-                    />
-                    
-                <SelectField 
-                    v-else-if="field.type === 'select'" 
-                    :field="field" 
-                    :store="store" 
-                    :data="useData ? data : {}" 
-                    />
-                    
-                <SearchableField 
-                    v-else-if="field.type === 'search'" 
-                    :field="field" 
-                    :store="store" 
-                    :data="useData ? data : {}" 
-                    />
-                    
-                <TextAreaField 
-                    v-else-if="field.type === 'text'" 
-                    :field="field" 
-                    :store="store" 
-                    :data="useData ? data : {}" 
-                    />
-            </div>                   
+    <div v-if="form.columns" class="grid grid-flow-col grid-cols-4">
+        <div v-for="col in form.columns" :class="col.className">
+            <section v-for="section in col.sections" class="grid">
+                <h2 v-if="section.title" class="mt-8 mb-3 font-bold text-[16px]">{{ $t(section.title) }}</h2>
+                <div v-if="!section.sectionType || section.sectionType ==='default'" v-for="row, index in section.rows" :key="index" class="grid grid-flow-col" :class="row.className">
+                    <div v-for="field in row.fields" :key="field.name" :class="field.className">
+                        <InputField 
+                            v-if="field.type === 'input'" 
+                            :field="field" 
+                            :store="store" 
+                            :data="useData ? (field.subfield ? data[field.name] :  data) : {}" 
+                            />
+                            
+                        <CheckboxField 
+                            v-else-if="field.type === 'check'" 
+                            :field="field" 
+                            :store="store" 
+                            :data="useData ? data : {}" 
+                            />
+                            
+                        <SelectField 
+                            v-else-if="field.type === 'select'" 
+                            :field="field" 
+                            :store="store" 
+                            :data="useData ? data : {}" 
+                            />
+                            
+                        <SearchableField 
+                            v-else-if="field.type === 'search'" 
+                            :field="field" 
+                            :store="store" 
+                            :data="useData ? data : {}" 
+                            />
+                            
+                        <TextAreaField 
+                            v-else-if="field.type === 'text'" 
+                            :field="field" 
+                            :store="store" 
+                            :data="useData ? data : {}" 
+                            />
+                    </div>                   
+                </div>
+                <div v-if="section.sectionType === 'parcelEditor'" class="grid grid-flow-col" :class="row?.className ?? ''">
+                    <ParcelEditor :fields="section.fields" :parent="content?.id" :store="store" :parcels="content[section.data]" />
+                </div>
+                <div v-if="section.sectionType === 'addressesEditor'" class="grid grid-flow-col" :class="row?.className ?? ''">
+                    <AddressesEditor :fields="section.fields" :parent="content?.id" :store="store" :addresses="content[section.data]" />
+                </div>
+                <div v-if="section.sectionType === 'financialsEditor'" class="grid grid-flow-col" :class="row?.className ?? ''">
+                    IN PROGRESS -> Finished Fr. 01.03.2024
+                </div>
+                <div v-if="section.sectionType === 'vehicleEditor'" class="grid grid-flow-col" :class="row?.className ?? ''">
+                    IN PROGRESS -> Finished Fr. 01.03.2024
+                </div>
+            </section>
         </div>
-        <div v-if="section.sectionType === 'parcelEditor'">
-            <ParcelEditor :fields="section.fields" :parent="content?.id" :store="store" :parcels="content[section.data]" />
-        </div>
-        <div v-if="section.sectionType === 'addressesEditor'">
-            <AddressesEditor :fields="section.fields" :parent="content?.id" :store="store" :addresses="content[section.data]" />
-        </div>
-        <div v-if="section.sectionType === 'financialsEditor'">
-            
-        </div>
-        <div v-if="section.sectionType === 'vehicleEditor'">
-            
-        </div>
-    </section>
+    </div>
     <div class="grid justify-end pt-4 pb-2 mt-4 border-t place-items-center border-t-slate-200">
         <slot name="actions"></slot>
     </div>

--- a/resources/js/Components/Inputs/SearchFilter.vue
+++ b/resources/js/Components/Inputs/SearchFilter.vue
@@ -1,0 +1,66 @@
+<script setup>
+    import SearchHelper from '@/lib/SearchHelper';
+    import { Search } from '@element-plus/icons-vue';
+    import { ref } from 'vue';
+    const props = defineProps({
+        searchConfig: {
+            type: Object,
+            required: true
+        }
+    })
+
+    var searchSections = ref(props.searchConfig);
+    var selectedSearchFields = ref([]);
+    var searchString = "";
+    const search = () => {
+        
+    }
+
+    const setSearchField = (field, relation = false) => {
+        let searchField = "";
+        if (relation !== false) {
+            searchField = relation + "__" + field;
+        } else {
+            searchField = field;
+        }
+
+        selectedSearchFields.value.push(searchField);
+    }
+
+    const isActive = (field, relation = false, activeFields) => {
+        let searchField = "";
+        if (relation !== false) {
+            searchField = relation + "__" + field;
+        } else {
+            searchField = field;
+        }
+
+        return activeFields.contains(searchField);
+    }
+</script>
+
+<template>
+    <button id="search-filter-dropdown-button" data-dropdown-toggle="search-filter-dropdown" class="flex items-center justify-center w-full gap-2 px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg md:w-auto focus:outline-none hover:bg-gray-100 hover:text-primary-700 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700" type="button">
+        <el-icon><Search /></el-icon>
+        <span>{{ $t('labels.general.search') }}</span>
+    </button>
+    <div id="search-filter-dropdown" class="z-50 hidden bg-white divide-y divide-gray-100 rounded shadow dark:bg-gray-700 dark:divide-gray-600">
+        <div class="p-2">
+            <input v-model="searchString" type="search" class="w-full p-2 text-sm text-gray-700 rounded-md outline-0 ring-0 focus:outline-0 focus:ring-0 focus:border-primary-700 dark:text-gray-200" :placeholder="$t('labels.general.search')" />
+            <button @click.prevent="search" class="w-full p-2 mt-2 text-sm text-white rounded-md bg-primary-700 dark:bg-primary-600">{{ $t('buttons.general.search') }}</button>
+        </div>
+        <div class="overflow-y-scroll max-h-48">
+            <ul v-for="section,si in searchSections" class="py-1 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="search-filter-dropdown-button">
+                <li class="uppercase border-t first:border-t-0 text-[14px] p-2 mb-2 px-4 whitespace-nowrap">{{ $t(section.sectionTitle ?? section.section ?? '') }}</li>
+                <li v-for="field,fi in section.fields" @click="setSearchField(field.name, section.relation)" :key="si + '.' + fi" class="grid px-4 pb-2">
+                    <label class="grid justify-start grid-flow-col gap-2">
+                        <input type="checkbox" /><span>{{ field.label }}</span>
+                    </label>
+                </li>
+            </ul>
+        </div>
+        <div class="py-1">
+            <a @click.prevent="reset" href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 dark:text-gray-200 dark:hover:text-white">{{ $t('buttons.general.reset_filters') }}</a>
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/Navbar/Navbar.vue
+++ b/resources/js/Components/Navbar/Navbar.vue
@@ -1,6 +1,6 @@
 <template>
     <nav
-        class="bg-white border-b border-gray-200 px-4 py-2.5 dark:bg-gray-800 dark:border-gray-700 fixed left-0 right-0 top-0 z-50">
+        class="bg-white border-b border-gray-200 px-4 py-2.5 dark:bg-gray-800 dark:border-gray-700 fixed left-0 right-0 top-0 z-[100]">
         <div class="flex flex-wrap items-center justify-between">
             <div class="flex items-center justify-start">
                 <button data-drawer-target="drawer-navigation" data-drawer-toggle="drawer-navigation"

--- a/resources/js/Components/Page.vue
+++ b/resources/js/Components/Page.vue
@@ -27,6 +27,10 @@
         metaData: {
             type: Object,
             required: false
+        },
+        searchConfig: {
+            type: Object,
+            required: false
         }
     });
 
@@ -48,10 +52,10 @@
             <h1 class="font-bold text-[18px] text-corporate-700">{{ $t(page?.title) }}</h1>
         </div>
         <div v-if="page.preset === 'simple-table' || page.preset === 'table'">
-            <SimpleTable :metaData="metaData" :tableConfig="tableConfig" :content="content" />
+            <SimpleTable :searchConfig="searchConfig" :metaData="metaData" :tableConfig="tableConfig" :content="content" />
         </div>
         <div v-else-if="page.preset === 'complex-table'">
-            <ComplexTable :metaData="metaData" :contentSettings="page.bodyContentSettings" :tableConfig="tableConfig" :content="content" />
+            <ComplexTable :searchConfig="searchConfig" :metaData="metaData" :contentSettings="page.bodyContentSettings" :tableConfig="tableConfig" :content="content" />
         </div>
         <div v-else-if="page.preset === 'tabs'">
             <TabContent :config="page" />

--- a/resources/js/Components/Tables/ComplexTable.vue
+++ b/resources/js/Components/Tables/ComplexTable.vue
@@ -5,9 +5,14 @@
     import ComplexTableContent from '@/Components/Tables/ComplexTableContent.vue';
     import TableHeaders from "@/lib/TableHeaders";
     import TableHeadCell from '@/Components/Tables/TableHeadCell.vue';
-import Pagination from '../Pagination/Pagination.vue';
+    import Pagination from '@/Components/Pagination/Pagination.vue';
+    import SearchFilter from '@/Components/Inputs/SearchFilter.vue';
     const props = defineProps({
         content: {
+            type: Object,
+            required: true
+        },
+        searchConfig: {
             type: Object,
             required: true
         },
@@ -50,20 +55,7 @@ import Pagination from '../Pagination/Pagination.vue';
     <div class="relative mt-5 bg-white dark:bg-gray-800 sm:rounded-lg">
         <div class="grid justify-between grid-flow-col py-3">
             <div>
-                <button id="search-filter-dropdown-button" data-dropdown-toggle="search-filter-dropdown" class="flex items-center justify-center w-full gap-2 px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg md:w-auto focus:outline-none hover:bg-gray-100 hover:text-primary-700 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700" type="button">
-                    <el-icon><Search /></el-icon>
-                    <span>Search Filter</span>
-                </button>
-                <div id="search-filter-dropdown" class="z-10 hidden bg-white divide-y divide-gray-100 rounded shadow w-44 dark:bg-gray-700 dark:divide-gray-600">
-                    <ul class="py-1 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="search-filter-dropdown-button">
-                        <li>
-                            <a href="#" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">Mass Edit</a>
-                        </li>
-                    </ul>
-                    <div class="py-1">
-                        <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 dark:text-gray-200 dark:hover:text-white">Delete all</a>
-                    </div>
-                </div>
+                <SearchFilter :searchConfig="searchConfig" />
             </div>
             <div>
                 <button id="actionsDropdownButton" data-dropdown-toggle="actionsDropdown" class="flex items-center justify-center w-full px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg md:w-auto focus:outline-none hover:bg-gray-100 hover:text-primary-700 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700" type="button">

--- a/resources/js/Components/Tables/ComplexTableContent.vue
+++ b/resources/js/Components/Tables/ComplexTableContent.vue
@@ -1,6 +1,6 @@
 <script setup>
 import TableCell from "@/Components/Tables/TableCell.vue"
-import { ArrowDown, Star, StarFilled, View } from "@element-plus/icons-vue";
+import { ArrowDown, CloseBold, Star, StarFilled, View } from "@element-plus/icons-vue";
 import { ref } from "vue";
 import OrderAddressBox from "@/Components/Boxes/OrderAddressBox.vue";
 import OrderParcelBox from "@/Components/Boxes/OrderParcelBox.vue";
@@ -43,6 +43,9 @@ const placeOnDashboard = (id) => {
 const isWatched = (id) => {
     return watchedItems.value.includes(id)
 }
+
+var _dd_ID = Math.random().toString(36).slice(2, 12);
+
 // Watched Items end
 
 </script>
@@ -94,6 +97,29 @@ const isWatched = (id) => {
                     :key="index"
                     :content="content" 
                     :field="field" />
+            </div>
+            <div class="grid justify-between grid-flow-col">
+                <!-- Buttons -->
+                <div class="grid justify-start grid-flow-col gap-4">
+                    <button class="grid justify-start grid-flow-col gap-2 p-3 px-4 text-white rounded-md place-items-center bg-primary-700 hover:bg-primary-500"><el-icon size="18"><View /></el-icon>{{ $t("buttons.general.edit") }}</button>
+                    <button class="grid justify-start grid-flow-col gap-2 p-3 px-4 text-white bg-red-700 rounded-md place-items-center hover:bg-red-500"><el-icon size="18"><CloseBold /></el-icon>{{ $t("buttons.general.void") }}</button>
+                </div>
+                <!-- Action Dropdowns -->
+                <div class="grid grid-flow-col gap-4 place-items-center">
+                    <div>{{  $t('labels.general.download_label') }}</div>
+                    <div class="relative z-50">
+                        <button :id="_dd_ID + '--file-download-dropdown-button'" class="" :data-dropdown-toggle="_dd_ID + '-file-download-dropdown'">
+                            {{  $t('labels.general.download_transport_details') }}
+                        </button>
+                        <div role="dropdown" class="hidden bg-white border rounded-md overflow-clip" :id="_dd_ID + '-file-download-dropdown'">
+                            <div class="w-full p-2 px-4 whitespace-nowrap hover:text-white hover:bg-primary-700">{{ $t('labels.general.download_in') }} {{ $t('lang.de') }}</div>
+                            <div class="w-full p-2 px-4 whitespace-nowrap hover:text-white hover:bg-primary-700">{{ $t('labels.general.download_in') }} {{ $t('lang.en') }}</div>
+                            <div class="w-full p-2 px-4 whitespace-nowrap hover:text-white hover:bg-primary-700">{{ $t('labels.general.download_in') }} {{ $t('lang.pl') }}</div>
+                            <div class="w-full p-2 px-4 whitespace-nowrap hover:text-white hover:bg-primary-700">{{ $t('labels.general.download_in') }} {{ $t('lang.ro') }}</div>
+                            <div class="w-full p-2 px-4 whitespace-nowrap hover:text-white hover:bg-primary-700">{{ $t('labels.general.download_in') }} {{ $t('lang.bg') }}</div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </td>
     </tr>

--- a/resources/js/Components/Tables/SimpleTable.vue
+++ b/resources/js/Components/Tables/SimpleTable.vue
@@ -6,6 +6,7 @@
     import TableHeaders from "@/lib/TableHeaders";
     import TableHeadCell from '@/Components/Tables/TableHeadCell.vue';
 import Pagination from '../Pagination/Pagination.vue';
+import SearchFilter from '../Inputs/SearchFilter.vue';
     const props = defineProps({
         content: {
             type: Object,
@@ -18,7 +19,11 @@ import Pagination from '../Pagination/Pagination.vue';
         tableConfig: {
             type: Object,
             required: true
-        }
+        },
+        searchConfig: {
+            type: Object,
+            required: true
+        },
     })
 
     onMounted(() => {
@@ -45,20 +50,7 @@ import Pagination from '../Pagination/Pagination.vue';
     <div class="relative mt-5 bg-white dark:bg-gray-800 sm:rounded-lg">
         <div class="grid justify-between grid-flow-col py-3">
             <div>
-                <button id="search-filter-dropdown-button" data-dropdown-toggle="search-filter-dropdown" class="flex items-center justify-center w-full gap-2 px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg md:w-auto focus:outline-none hover:bg-gray-100 hover:text-primary-700 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700" type="button">
-                    <el-icon><Search /></el-icon>
-                    <span>Search Filter</span>
-                </button>
-                <div id="search-filter-dropdown" class="z-10 hidden bg-white divide-y divide-gray-100 rounded shadow w-44 dark:bg-gray-700 dark:divide-gray-600">
-                    <ul class="py-1 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="search-filter-dropdown-button">
-                        <li>
-                            <a href="#" class="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">Mass Edit</a>
-                        </li>
-                    </ul>
-                    <div class="py-1">
-                        <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 dark:text-gray-200 dark:hover:text-white">Delete all</a>
-                    </div>
-                </div>
+                <SearchFilter :searchConfig="searchConfig" />
             </div>
             <div>
                 <button id="actionsDropdownButton" data-dropdown-toggle="actionsDropdown" class="flex items-center justify-center w-full px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg md:w-auto focus:outline-none hover:bg-gray-100 hover:text-primary-700 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700" type="button">

--- a/resources/js/Components/Tabs.vue
+++ b/resources/js/Components/Tabs.vue
@@ -32,16 +32,14 @@ onMounted(() => {
             </li>
         </ul>
     </div>
-    <div id="default-tab-content">
+    <div id="default-tab-content" class="w-full">
         <div
             class="hidden"
             v-for="tab in config.tabs" 
             :id="tab.id" 
             role="tabpanel" 
             :aria-labelledby="tab.id + '-tab'">
-            <div class="grid grid-cols-12 col-span-12">
-                <component :is="tab.component" />
-            </div>
+            <component :is="tab.component" />
         </div>
     </div>
 

--- a/resources/js/Pages/Addresses/Index.vue
+++ b/resources/js/Pages/Addresses/Index.vue
@@ -8,6 +8,7 @@ import Button from '@/Components/Buttons/Button.vue';
 const actionHandle = new Actions( route )
 
 import tableHeaderConfig from "@/config/Tables/addressHeaders"; 
+import searchConfig from "@/config/SearchFilters/addressSearch"; 
 defineProps({
     records: {
         type: Object,
@@ -17,7 +18,7 @@ defineProps({
 
 </script>
 <template>
-    <Page :metaData="records.meta" :tableConfig="tableHeaderConfig" :content="records.data" :page="config">
+    <Page :metaData="records.meta" :searchConfig="searchConfig" :tableConfig="tableHeaderConfig" :content="records.data" :page="config">
         <template #create-button>
             <Button type="create" @click="actionHandle.create()"/>
         </template>

--- a/resources/js/Pages/Customers/Index.vue
+++ b/resources/js/Pages/Customers/Index.vue
@@ -8,7 +8,7 @@ import Button from '@/Components/Buttons/Button.vue';
 const actionHandle = new Actions( route )
 
 import tableHeaderConfig from "@/config/Tables/customerHeaders";
-
+import searchConfig from "@/config/SearchFilters/customerSearch"; 
 defineProps({
     records: {
         type: Object,
@@ -17,7 +17,7 @@ defineProps({
 })
 </script>
 <template>
-    <Page :metaData="records.meta" :tableConfig="tableHeaderConfig" :content="records.data" :page="config">
+    <Page :metaData="records.meta" :searchConfig="searchConfig" :tableConfig="tableHeaderConfig" :content="records.data" :page="config">
         <template #create-button>
             <Button type="create" @click="actionHandle.create()"/>
         </template>

--- a/resources/js/Pages/Forwarders/Index.vue
+++ b/resources/js/Pages/Forwarders/Index.vue
@@ -8,6 +8,7 @@ import Button from '@/Components/Buttons/Button.vue';
 const actionHandle = new Actions( route )
 
 import tableHeaderConfig from "@/config/Tables/forwarderHeaders";
+import searchConfig from "@/config/SearchFilters/forwarderSearch"; 
 defineProps({
     records: {
         type: Object,
@@ -18,7 +19,7 @@ defineProps({
 
 </script>
 <template>
-    <Page :metaData="records.meta" :tableConfig="tableHeaderConfig" :content="records.data" :page="config">
+    <Page :metaData="records.meta" :searchConfig="searchConfig" :tableConfig="tableHeaderConfig" :content="records.data" :page="config">
         <template #create-button>
             <Button type="create" @click="actionHandle.create()"/>
         </template>

--- a/resources/js/Pages/Orders/Index.vue
+++ b/resources/js/Pages/Orders/Index.vue
@@ -8,7 +8,7 @@ import Button from '@/Components/Buttons/Button.vue';
 const actionHandle = new Actions( route )
 
 import tableHeaderConfig from "@/config/Tables/orderHeaders"; 
-
+import searchConfig from "@/config/SearchFilters/orderSearch"; 
 defineProps({
     records: {
         type: Object,
@@ -18,7 +18,7 @@ defineProps({
 
 </script>
 <template>
-    <Page :metaData="records.meta" :tableConfig="tableHeaderConfig" :content="records.data" :page="config">
+    <Page :metaData="records.meta" :searchConfig="searchConfig" :tableConfig="tableHeaderConfig" :content="records.data" :page="config">
         <template #create-button>
             <Button type="create" @click="actionHandle.create()"/>
         </template>

--- a/resources/js/Pages/Vehicles/Index.vue
+++ b/resources/js/Pages/Vehicles/Index.vue
@@ -8,6 +8,8 @@ import Button from '@/Components/Buttons/Button.vue';
 const actionHandle = new Actions( route )
 
 import tableHeaderConfig from "@/config/Tables/vehicleHeaders";
+import searchConfig from "@/config/SearchFilters/vehiclesSearch"; 
+
 defineProps({
     records: {
         type: Object,
@@ -16,7 +18,7 @@ defineProps({
 })
 </script>
 <template>
-    <Page :metaData="records.meta" :tableConfig="tableHeaderConfig" :content="records.data" :page="config">
+    <Page :metaData="records.meta" :searchConfig="searchConfig" :tableConfig="tableHeaderConfig" :content="records.data" :page="config">
         <template #create-button>
             <Button type="create" @click="actionHandle.create()"/>
         </template>

--- a/resources/js/config/Pages/Customers/Form/_config.js
+++ b/resources/js/config/Pages/Customers/Form/_config.js
@@ -31,36 +31,36 @@ export default {
                         type: "text"
                     },
                 ]},
-                {className: 'grid-flow-row grid-cols-4 gap-4', fields: [
-                    {
-                        name: "street",
-                        className: "col-auto",
-                        label: "pages.customers.form.street", 
-                        placeholder: "pages.customers.form.street", 
-                        type: "text"
-                    },
-                    {
-                        name: "house_number",
-                        className: "col-auto",
-                        label: "pages.customers.form.house_number", 
-                        placeholder: "pages.customers.form.house_number", 
-                        type: "text"
-                    },
-                    {
-                        name: "zip_code",
-                        className: "col-auto",
-                        label: "pages.customers.form.zip_code", 
-                        placeholder: "pages.customers.form.zip_code", 
-                        type: "text"
-                    },
-                    {
-                        name: "city",
-                        className: "col-auto",
-                        label: "pages.customers.form.city", 
-                        placeholder: "pages.customers.form.city", 
-                        type: "text"
-                    }
-                ]},
+                // {className: 'grid-flow-row grid-cols-4 gap-4', fields: [
+                //     {
+                //         name: "street",
+                //         className: "col-auto",
+                //         label: "pages.customers.form.street", 
+                //         placeholder: "pages.customers.form.street", 
+                //         type: "text"
+                //     },
+                //     {
+                //         name: "house_number",
+                //         className: "col-auto",
+                //         label: "pages.customers.form.house_number", 
+                //         placeholder: "pages.customers.form.house_number", 
+                //         type: "text"
+                //     },
+                //     {
+                //         name: "zip_code",
+                //         className: "col-auto",
+                //         label: "pages.customers.form.zip_code", 
+                //         placeholder: "pages.customers.form.zip_code", 
+                //         type: "text"
+                //     },
+                //     {
+                //         name: "city",
+                //         className: "col-auto",
+                //         label: "pages.customers.form.city", 
+                //         placeholder: "pages.customers.form.city", 
+                //         type: "text"
+                //     }
+                // ]},
                 {className: 'grid-flow-row gap-4', fields: [
                     {
                         name: "first_name",

--- a/resources/js/config/Pages/Orders/Form/_details.js
+++ b/resources/js/config/Pages/Orders/Form/_details.js
@@ -1,166 +1,178 @@
 export default {
-    sections: [
+    columns: [
         {
-            title: "pages.orders.form.sections.order_details",
-            sectionType: "default",
-            collapsible: true,
-            rows: [
+            className: 'col-span-3',
+            sections: [
                 {
-                    className: 'grid grid-flow-row grid-cols-2 gap-4',
-                    fields: [
+                    title: "pages.orders.form.sections.order_details",
+                    sectionType: "default",
+                    collapsible: true,
+                    rows: [
                         {
-                            name: 'type_of_transport',
-                            className: 'col-6',
-                            placeholder: 'pages.orders.form.type_of_transport',
-                            label: 'pages.orders.form.type_of_transport',
-                            type: 'text',
+                            className: 'grid grid-flow-row grid-cols-2 gap-4',
+                            fields: [
+                                {
+                                    name: 'type_of_transport',
+                                    className: 'col-auto',
+                                    placeholder: 'pages.orders.form.type_of_transport',
+                                    label: 'pages.orders.form.type_of_transport',
+                                    type: 'text',
+                                },
+                                {
+                                    name: 'order_status_id',
+                                    type: 'select',
+                                    options: "orderstatuses",
+                                    displayKey: 'internal_name',
+                                    match: "id",
+                                    className: 'col-auto',
+                                    placeholder: 'pages.orders.form.order_status',
+                                    label: 'pages.orders.form.order_status',
+                                },
+                            ]
                         },
                         {
-                            name: 'order_status_id',
-                            type: 'select',
-                            options: "orderstatuses",
-                            displayKey: 'internal_name',
-                            match: "id",
-                            className: 'col-6',
-                            placeholder: 'pages.orders.form.order_status',
-                            label: 'pages.orders.form.order_status',
+                            className: 'grid grid-flow-row grid-cols-4 gap-4',
+                            fields: [
+                                {
+                                    name: 'id',
+                                    subfield: 'partner',
+                                    className: 'col-auto',
+                                    type: 'select',
+                                    options: "partners",
+                                    displayKey: 'company_name',
+                                    match: "id",
+                                    placeholder: 'pages.orders.form.partner',
+                                    label: 'pages.orders.form.partner',
+                                },
+                                {
+                                    name: 'origin',
+                                    className: 'col-auto',
+                                    type: 'select',
+                                    options: "origins",
+                                    displayKey: 'title',
+                                    match: 'id',
+                                    placeholder: 'pages.orders.form.origin',
+                                    label: 'pages.orders.form.origin',
+                                },
+                                {
+                                    name: 'customer_reference',
+                                    className: 'col-auto',
+                                    type: 'text',
+                                    placeholder: 'pages.orders.form.customer_refernce',
+                                    label: 'pages.orders.form.customer_refernce',
+                                },
+                                {
+                                    name: "details",
+                                    subfield: 'distance_km',
+                                    className: 'col-auto',
+                                    type: 'text',
+                                    placeholder: 'pages.orders.form.distance_km',
+                                    label: 'pages.orders.form.distance_km',
+                                },
+                            ]
+                        },
+                        {
+                            className: 'grid-flow-row gap-4',
+                            fields: [
+                                {
+                                    name: 'duration_minutes',
+                                    className: 'col-auto',
+                                    type: 'text',
+                                    placeholder: 'pages.orders.form.duration_minutes',
+                                    label: 'pages.orders.form.duration_minutes',
+                                },
+                                {
+                                    name: 'calculation_model_name',
+                                    className: 'col-auto',
+                                    type: 'text',
+                                    placeholder: 'pages.orders.form.calculation_model_name',
+                                    label: 'pages.orders.form.calculation_model_name',
+                                },
+                            ]
+                        },
+                        {
+                            className: 'grid-flow-row gap-4',
+                            fields: [
+                                {
+                                    name: 'particularities',
+                                    className: 'col-auto',
+                                    type: 'text',
+                                    placeholder: 'pages.orders.form.particularities',
+                                    label: 'pages.orders.form.particularities',
+                                },
+                                {
+                                    name: 'description_of_transport',
+                                    className: 'col-auto',
+                                    type: 'text',
+                                    placeholder: 'pages.orders.form.description_of_transport',
+                                    label: 'pages.orders.form.description_of_transport',
+                                }
+                            ]
                         },
                     ]
                 },
                 {
-                    className: 'grid grid-flow-row grid-cols-4 gap-4',
+                    title: "pages.orders.form.sections.parcels",
+                    sectionType: "parcelEditor",
+                    collapsible: true,
+                    data: "parcels",
                     fields: [
                         {
-                            name: 'partner',
-                            className: 'col-3',
-                            type: 'select',
-                            options: "partners",
-                            displayKey: 'company_name',
-                            match: "id",
-                            placeholder: 'pages.orders.form.partner',
-                            label: 'pages.orders.form.partner',
+                            name: 'length',
+                            type: 'text',
+                            keyName: 'id',
+                            className: 'col-auto',
+                            placeholder: 'pages.orders.form.length',
+                            label: 'pages.orders.form.length',
                         },
                         {
-                            name: 'origin',
-                            className: 'col-3',
+                            name: 'width',
                             type: 'text',
-                            placeholder: 'pages.orders.form.origin',
-                            label: 'pages.orders.form.origin',
+                            className: 'col-auto',
+                            placeholder: 'pages.orders.form.width',
+                            label: 'pages.orders.form.width',
                         },
                         {
-                            name: 'customer_reference',
-                            className: 'col-3',
+                            name: 'height',
                             type: 'text',
-                            placeholder: 'pages.orders.form.customer_refernce',
-                            label: 'pages.orders.form.customer_refernce',
+                            className: 'col-auto',
+                            placeholder: 'pages.orders.form.height',
+                            label: 'pages.orders.form.height',
                         },
                         {
-                            name: "details",
-                            subfield: 'distance_km',
-                            className: 'col-3',
+                            name: 'weight',
                             type: 'text',
-                            placeholder: 'pages.orders.form.distance_km',
-                            label: 'pages.orders.form.distance_km',
+                            className: 'col-auto',
+                            placeholder: 'pages.orders.form.weight',
+                            label: 'pages.orders.form.weight',
                         },
                     ]
                 },
                 {
-                    className: 'grid-flow-row gap-4',
-                    fields: [
-                        {
-                            name: 'duration_minutes',
-                            className: 'col-auto',
-                            type: 'text',
-                            placeholder: 'pages.orders.form.duration_minutes',
-                            label: 'pages.orders.form.duration_minutes',
-                        },
-                        {
-                            name: 'calculation_model_name',
-                            className: 'col-auto',
-                            type: 'text',
-                            placeholder: 'pages.orders.form.calculation_model_name',
-                            label: 'pages.orders.form.calculation_model_name',
-                        },
-                    ]
+                    title: "pages.orders.form.sections.addresses",
+                    sectionType: "addressesEditor",
+                    collapsible: true,
+                    data: "addresses",
+                    rows: []
                 },
                 {
-                    className: 'grid-flow-row gap-4',
-                    fields: [
-                        {
-                            name: 'particularities',
-                            className: 'col-auto',
-                            type: 'text',
-                            placeholder: 'pages.orders.form.particularities',
-                            label: 'pages.orders.form.particularities',
-                        },
-                        {
-                            name: 'description_of_transport',
-                            className: 'col-auto',
-                            type: 'text',
-                            placeholder: 'pages.orders.form.description_of_transport',
-                            label: 'pages.orders.form.description_of_transport',
-                        }
-                    ]
+                    title: "pages.orders.form.sections.finances",
+                    sectionType: "financialsEditor",
+                    collapsible: true,
+                    data: "finances",
+                    rows: []
                 },
+                {
+                    title: "pages.orders.form.sections.vehicles",
+                    sectionType: "vehicleEditor",
+                    collapsible: true,
+                    data: "vehicles",
+                    rows: []
+                }
             ]
         },
         {
-            title: "pages.orders.form.sections.parcels",
-            sectionType: "parcelEditor",
-            collapsible: true,
-            data: "parcels",
-            fields: [
-                {
-                    name: 'length',
-                    type: 'text',
-                    keyName: 'id',
-                    className: 'col-auto',
-                    placeholder: 'pages.orders.form.length',
-                    label: 'pages.orders.form.length',
-                },
-                {
-                    name: 'width',
-                    type: 'text',
-                    className: 'col-auto',
-                    placeholder: 'pages.orders.form.width',
-                    label: 'pages.orders.form.width',
-                },
-                {
-                    name: 'height',
-                    type: 'text',
-                    className: 'col-auto',
-                    placeholder: 'pages.orders.form.height',
-                    label: 'pages.orders.form.height',
-                },
-                {
-                    name: 'weight',
-                    type: 'text',
-                    className: 'col-auto',
-                    placeholder: 'pages.orders.form.weight',
-                    label: 'pages.orders.form.weight',
-                },
-            ]
-        },
-        {
-            title: "pages.orders.form.sections.addresses",
-            sectionType: "addressesEditor",
-            collapsible: true,
-            data: "addresses",
-            rows: []
-        },
-        {
-            title: "pages.orders.form.sections.finances",
-            sectionType: "financialsEditor",
-            collapsible: true,
-            data: "finances",
-            rows: []
-        },
-        {
-            title: "pages.orders.form.sections.vehicles",
-            sectionType: "vehicleEditor",
-            collapsible: true,
-            data: "vehicles",
-            rows: []
+            className: '',
         }
     ]
 }

--- a/resources/js/config/SearchFilters/customerSearch.js
+++ b/resources/js/config/SearchFilters/customerSearch.js
@@ -1,15 +1,36 @@
 export default [
     { 
-        section: 'filter-labels.order',
+        sectionTitle: 'labels.filter.customer_base',
         relation: false,
         fields: [
-            { name: 'order_number', label: 'labels.order_number', type: 'text' },
-            { name: 'customer_reference', label: 'labels.customer_reference', type: 'text' },
-            { name: 'order_status', label: 'labels.order_status', type: 'select', options: ['Pending', 'Processing', 'Completed', 'Cancelled'] },
-            { name: 'payment_status', label: 'labels.payment_status', type: 'select', options: ['Pending', 'Processing', 'Completed', 'Cancelled'] },
-            { name: 'payment_method', label: 'labels.payment_method', type: 'select', options: ['Cash', 'Bank Transfer', 'Credit Card'] },
-            { name: 'order_date', label: 'labels.order_date', type: 'date' },
-            { name: 'delivery_date', label: 'labels.delivery_date', type: 'date' },
+            { 
+                name: 'order_number', 
+                label: 'labels.order_number' 
+            },
+            { 
+                name: 'customer_reference', 
+                label: 'labels.customer_reference' 
+            },
+            { 
+                name: 'order_status', 
+                label: 'labels.order_status'
+            },
+            { 
+                name: 'payment_status', 
+                label: 'labels.payment_status'
+            },
+            { 
+                name: 'payment_method', 
+                label: 'labels.payment_method'
+            },
+            { 
+                name: 'order_date', 
+                label: 'labels.order_date' 
+            },
+            { 
+                name: 'delivery_date', 
+                label: 'labels.delivery_date' 
+            },
         ]
     }
 ]

--- a/resources/js/lib/Data.js
+++ b/resources/js/lib/Data.js
@@ -5,6 +5,10 @@ export default class Data {
         let countries = await axios.get('/api/countries');
         return countries;
     }
+    async #origins(){
+        let origins = await axios.get('/api/origins');
+        return origins;
+    }
     async #ratings(){
         let ratings = await axios.get('/api/ratings');
         return ratings;
@@ -51,6 +55,8 @@ export default class Data {
         switch(target){
             case 'countries':
                 return await this.#countries();
+            case 'origins':
+                return await this.#origins();
             case 'ratings':
                 return await this.#ratings();
             case 'ism':

--- a/resources/js/lib/SearchHelper.js
+++ b/resources/js/lib/SearchHelper.js
@@ -1,0 +1,3 @@
+export default class SearchHelper {
+    
+};

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -55,7 +55,11 @@
         "en": "Englisch",
         "it": "Italienisch",
         "es": "Spanisch",
-        "fr": "Französisch"
+        "fr": "Französisch",
+        "pl": "Polnisch",
+        "ru": "Russisch",
+        "bg": "Bulgarisch",
+        "ro": "Rumänisch"
     },
     "buttons": {
         "general": {
@@ -66,7 +70,9 @@
             "edit": "Bearbeiten",
             "new": "Neu",
             "reset": "Zurücksetzen",
+            "reset_filters": "Filter zurücksetzen",
             "save": "Speichern",
+            "void": "Stornieren",
             "search": "Suchen",
             "submit": "Absenden",
             "update": "Aktualisieren",
@@ -371,6 +377,7 @@
         "address-billing": "Rechnungsadresse",
         "address-headquarter": "Hauptsitz",
         "general": {
+            "search": "Einträge suchen",
             "measurements": "Maße",
             "weight": "Gewicht",
             "name": "Name",
@@ -380,7 +387,38 @@
             "customer_number": "Kundennummer",
             "distance_km": "Entfernung (km)",
             "duration_minutes": "Dauer (min)",
-            "price_net": "Preis netto"
+            "price_net": "Preis netto",
+            "download_in": "Download in",
+            "download_label": "Versandlabel",
+            "download_transport_details": "Transportauftrag"
+        },
+        "filter": {
+            "customer_base": "Kundenstamm",
+            "forwarder_base": "",
+            "vehicle_base": "",
+            "address_base": "",
+            "order_base": ""
+        },
+
+
+        "mail": "E-Mail",
+        "password": "Passwort",
+        "forgot-password": "Passwort zurücksetzen",
+        "stay-logged-in": "Angemeldet bleiben?"
+    },
+    "login": {
+        "title": "Anmelden",
+        "description": "Bitte melden Sie sich an, um fortzufahren."
+    },
+    "button": {
+        "login": "Einloggen",
+        "back-login": "Zurück zum Login",
+        "request-password": "Anfrage senden"
+    },
+    "password": {
+        "forgot": {
+            "headline": "Passwort vergessen?",
+            "info": "Bitte geben Sie Ihre E-Mail-Adresse ein, um Ihr Passwort zurückzusetzen."
         }
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Models\TmsPartner;
 use App\Models\TmsPaymentMethod;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use function PHPUnit\Framework\directoryExists;
 
 /*
 |--------------------------------------------------------------------------
@@ -25,6 +26,13 @@ Route::middleware('auth:sanctum')->group(function(){
 
     Route::get('/countries', function (Request $request){
         return TmsCountry::all();
+    });
+    
+    Route::get('/origins', function (Request $request){
+        return [
+            ["id" => 1, "title" => "general.origins.pamyra"],
+            ["id" => 2, "title" => "general.origins.native"]
+        ];
     });
 
     


### PR DESCRIPTION
- Changed the `sections` property to `columns` in the default export object.
- Removed the unnecessary `className` property from the first section.
- Reorganized the structure of the `order_details` section.
- Removed the unnecessary `className` property from the `fields` array.
- Reorganized the structure of the `order_details` section's `fields` array.
- Updated the `className` property of the `partner` field.
- Updated the structure of the `origin` field and added a `subfield` property.

These changes were made to improve the layout and organization of the order details form.