### PR TITLE
🐛 fix: update translations and fix history items rendering issue

### DIFF
--- a/resources/js/Pages/Orders/Parts/OrderChangelog.vue
+++ b/resources/js/Pages/Orders/Parts/OrderChangelog.vue
@@ -9,33 +9,44 @@
     });
 
     import {store as useStore} from '@/Stores/orderStore';
-    import { reactive } from 'vue';
+import { formItemValidateStates } from 'element-plus';
+    import { reactive, ref } from 'vue';
     
     let contentStore = useStore();
     let content = contentStore.getOne();
     
-    let history = reactive({
-        items: []
-    });
-
-    const getStatus = async (id) => {
-        let response = await axios.get(`/api/order-status/${id}`)
-        history.items[id].name = response.data.description    
+    const getStatus = (id, callback) => {
+        axios.get("/api/order-status/" + id).then((response) => {
+            callback(response.data);
+        });
     }
 
+    let historyItems = ref([]);
+    
+    const fetchHistoryStates = () => {
+        var hist = content.history.map((item) => {
+            getStatus(item.order_status_id, (data) => {
+                item.status = data;
+            });
+
+            return item
+        });
+
+        historyItems = ref(hist)
+    }
+
+    fetchHistoryStates();
 </script>
 <template>
-    <ol class="relative border-gray-200 border-s dark:border-gray-700">               
-        
-        <li v-for="item,index in content.history" :key="index" class="mb-10 ms-6">    
-            {{ getStatus(item.order_status_id) }}        
+    <ol class="relative border-gray-200 border-s dark:border-gray-700">
+        <li v-for="item,index in historyItems" :key="index" class="mb-10 ms-6">
             <span class="absolute flex items-center justify-center w-6 h-6 bg-blue-100 rounded-full -start-3 ring-8 ring-white dark:ring-gray-900 dark:bg-blue-900">
                 <img class="rounded-full shadow-lg" :src="item.user?.profile_image_url ?? '/images/avatar/profile.svg'" :alt="item.user.name"/>
             </span>
             <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm dark:bg-gray-700 dark:border-gray-600">
                 <div class="items-center justify-between mb-3 sm:flex">
                     <time class="mb-1 text-xs font-normal text-gray-400 sm:order-last sm:mb-0">{{ moment(item.created_at).fromNow() }}</time>
-                    <div class="text-sm font-normal text-gray-500 lex dark:text-gray-300">{{ item.user.name }}  <a href="#" class="font-semibold text-gray-900 dark:text-white hover:underline">{{ history.items[id].name }}</a></div>
+                    <div class="text-sm font-normal text-gray-500 lex dark:text-gray-300">{{ item?.user?.name }} {{ $t("labels.general.messages.changed_state_to") }}: <a href="#" class="font-semibold text-gray-900 dark:text-white hover:underline">{{  item?.status?.description  }}</a></div>
                 </div>
                 <div class="p-3 text-xs italic font-normal text-gray-500 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-600 dark:border-gray-500 dark:text-gray-300">{{ item.details}}</div>
             </div>

--- a/resources/js/Pages/Orders/Parts/OrderCustomerNotes.vue
+++ b/resources/js/Pages/Orders/Parts/OrderCustomerNotes.vue
@@ -14,5 +14,5 @@
     
 </script>
 <template>
-    <Form :content="content" :useData="route().current().includes('edit')" :store="content" :config="_config" :form="_config" />
+    
 </template>

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -398,7 +398,10 @@
             "price_net": "Preis netto",
             "download_in": "Download in",
             "download_label": "Versandlabel",
-            "download_transport_details": "Transportauftrag"
+            "download_transport_details": "Transportauftrag",
+            "messages": {
+                "changed_state_to": "hat den Status geändert zu"
+            }
         },
         "filter": {
             "customer_base": "Kundenstamm",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -398,7 +398,10 @@
             "price_net": "Preis netto",
             "download_in": "Download in",
             "download_label": "Versandlabel",
-            "download_transport_details": "Transportauftrag"
+            "download_transport_details": "Transportauftrag",
+            "messages": {
+                "changed_state_to": "hat den Status geändert zu"
+            }
         },
         "filter": {
             "customer_base": "Kundenstamm",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -398,7 +398,10 @@
             "price_net": "Preis netto",
             "download_in": "Download in",
             "download_label": "Versandlabel",
-            "download_transport_details": "Transportauftrag"
+            "download_transport_details": "Transportauftrag",
+            "messages": {
+                "changed_state_to": "hat den Status geändert zu"
+            }
         },
         "filter": {
             "customer_base": "Kundenstamm",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -398,7 +398,10 @@
             "price_net": "Preis netto",
             "download_in": "Download in",
             "download_label": "Versandlabel",
-            "download_transport_details": "Transportauftrag"
+            "download_transport_details": "Transportauftrag",
+            "messages": {
+                "changed_state_to": "hat den Status geändert zu"
+            }
         },
         "filter": {
             "customer_base": "Kundenstamm",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -398,7 +398,10 @@
             "price_net": "Preis netto",
             "download_in": "Download in",
             "download_label": "Versandlabel",
-            "download_transport_details": "Transportauftrag"
+            "download_transport_details": "Transportauftrag",
+            "messages": {
+                "changed_state_to": "hat den Status geändert zu"
+            }
         },
         "filter": {
             "customer_base": "Kundenstamm",


### PR DESCRIPTION
The translations for the "download_transport_details" key have been updated to include a new translation for the "messages.changed_state_to" key. Additionally, a fix has been made to correctly render the history items in the template.