### PR TITLE
🔨 chore: update grid layout and styles in orders form

### DIFF
--- a/resources/js/Components/Inputs/InputField.vue
+++ b/resources/js/Components/Inputs/InputField.vue
@@ -24,7 +24,7 @@
 
     const defaultWrapperClass = 'relative ' + ' w-full ';
     const defaultLabelClass = '' + 'absolute ' + 'top-0 ' + 'start-1 ' + 'px-2 ' + 'text-[15px] ' + '-translate-y-1/2 ' + 'bg-white ' + 'peer-focus:text-corporate-700 ' + 'peer-placeholder-shown:top-1/2 ' + 'peer-focus:top-0 ' + 'transition-all ' + 'duration-300 ' + 'pointer-events-none ';
-    const defaultInputClass = '' + 'rounded-md '  + 'w-full ' + 'peer ' + 'pr-8 ' + 'text-[15px] ' + 'text-black ' + 'border-gray-300 ' + 'focus:border-primary-700 ' + 'ring-0 ' + 'focus:ring-0 ';
+    const defaultInputClass = '' + 'rounded-md '  + 'w-full ' + 'peer ' + (props.field.tooltipText !== '' ? 'pr-8 ' : 'pr-0 ') + 'text-[15px] ' + 'text-black ' + 'border-gray-300 ' + 'focus:border-primary-700 ' + 'ring-0 ' + 'focus:ring-0 ';
     const defaultIconWrapperClass = '' + 'absolute ' + 'top-0 ' + 'end-2.5 ' + 'top-1/2 ' + '-translate-y-1/2 ';
     
     const _id = Math.random().toString(36).substring(7);

--- a/resources/js/Components/Inputs/SelectField.vue
+++ b/resources/js/Components/Inputs/SelectField.vue
@@ -31,7 +31,10 @@
     }
     
     getOptions()
-    const getDisplayData = (from, config, translator) => {
+    const getDisplayData = (from, config, translate) => {
+
+        return translate(from[config]);
+        
         let displayString = [];
         if(config.includes('|')){
             let keys = config.split('|')
@@ -73,16 +76,16 @@
 </script>
 
 <template>
-        <div class="relative z-30 flex w-full">
+        <div class="relative flex w-full">
             <button 
-            class="grid justify-between w-full grid-flow-col p-3 py-2 border min-h-[42px] rounded-md place-items-center border-gray-300"
+            class="grid justify-between w-full z-10 grid-flow-col p-3 py-2 border min-h-[42px] rounded-md place-items-center border-gray-300"
             :id="_id + '-dropdown-button'"
             :data-dropdown-toggle="_id + '-dropdown'"
             @click="open = !!!open"
             >   
-            {{ getActiveOption() !== undefined ? getActiveOption()[field.displayKey] : "" }} <el-icon><ArrowDown v-if="!open"/><ArrowUp v-else/></el-icon>
+            {{ getActiveOption() !== undefined ? $t(getActiveOption()[field.displayKey]) : "" }} <el-icon><ArrowDown v-if="!open"/><ArrowUp v-else/></el-icon>
             </button>
-            <div class="absolute hidden w-full bg-white border rounded-md overflow-clip text-corporate-700" :id="_id + '-dropdown'">
+            <div class="absolute z-50 hidden w-full bg-white border rounded-md overflow-clip text-corporate-700 min-w-max" :id="_id + '-dropdown'">
                 <div v-for="(option, index) in options"
                 @click="() => {
                     store.update(field.name, option[field.match])

--- a/resources/js/Pages/Orders/Parts/OrderEditDetails.vue
+++ b/resources/js/Pages/Orders/Parts/OrderEditDetails.vue
@@ -11,9 +11,10 @@
 
 
     import {store as useStore} from '@/Stores/orderStore';
-    import { CopyDocument, Delete, Plus } from '@element-plus/icons-vue';
+    import { ArrowDown, CopyDocument, Delete, Plus } from '@element-plus/icons-vue';
     import OrderCalcHelper from "@/lib/OrderCalcHelper.js";
 
+    console.log(_config.sections.general)
     defineProps({
         useContent: {
             type: Boolean,
@@ -106,8 +107,8 @@
         <div class="grid col-span-3 gap-4 px-4">
             <p>Auftragsdetails</p>
             <div class="grid gap-4">
-                <div v-for="row in _config.sections.general.rows" class="grid grid-flow-row" :class="row.className">
-                    <div v-for="field in row.fields" :key="field.name" :class="field.className">
+                <div v-for="row in _config.sections.general.rows" class="grid grid-flow-row " :class="{[row.className]: true}">
+                    <div v-for="field in row.fields" :key="field.name" class="col-auto" :class="{[field.className]: true}">
                         <InputField 
                             v-if="field.type === 'input'" 
                             :field="field" 
@@ -149,7 +150,10 @@
             <p>Packstücke</p>
             <div class="grid gap-4">
                 <div v-for="parcel,index in state.parcels" :key="index" class="grid grid-flow-col gap-4">
-                    <div v-for="field in _config.sections.parcels.fields" class="">
+                    <div class="grid justify-center w-6 place-items-center">
+                        <span class="grid font-bold text-corporate-700 text-1 place-items-center">{{index + 1}}</span>
+                    </div>
+                    <div v-for="field in _config.sections.parcels.fields">
                         
                         <BindableTextField 
                             v-if="field.type === 'text'" 
@@ -239,15 +243,27 @@
             </div>
             <p>Adressen</p>
             <div class="grid max-w-full grid-flow-col gap-4 pb-4 overflow-x-scroll">
-                <div v-for="address in content.addresses" class="w-[300px] p-3 bg-slate-50 rounded-md">
-                    <div v-for="row in _config.sections.addresses.rows" class="grid grid-flow-col gap-4 mb-4 last:mb-0">
-                        <div v-for="field in row.fields" class="grid gap-4">
+                <div v-for="address,ai in content.addresses" class="w-[350px] p-3 bg-slate-50 rounded-md">
+                    <div v-for="row,ri in _config.sections.addresses.rows" class="grid grid-flow-col gap-4 mb-4 last:mb-0" :class="row.className">
+                        <div v-for="field,fi in row.fields" class="grid gap-4" :class="field.className">
+                            <div class="relative pt-8" v-if="field.type==='badge_dd'">
+                                <span class="absolute top-0 right-0 px-3 text-white duration-200 rounded-full cursor-pointer hover:bg-primary-600 bg-primary-700" :data-dropdown-toggle="`${ai}_${ri}_${fi}`">{{ $t(address[field.name]) }}</span>
+                                <div role="dropdown" :id="`${ai}_${ri}_${fi}`" class="hidden z-[100] bg-white rounded-md cursor-pointer overflow-clip shadow-md">
+                                    <ul>
+                                        <li class="p-1 px-3 hover:bg-primary-700 hover:text-white">{{ $t("general.badge.address.pickup") }}</li>
+                                        <li class="p-1 px-3 hover:bg-primary-700 hover:text-white">{{ $t("general.badge.address.delivery") }}</li>
+                                        <li class="p-1 px-3 hover:bg-primary-700 hover:text-white">{{ $t("general.badge.address.billing") }}</li>
+                                        <li class="p-1 px-3 hover:bg-primary-700 hover:text-white">{{ $t("general.badge.address.headquarter") }}</li>
+                                    </ul>
+                                </div>
+
+                            </div>
                             <BindableTextField 
                                 v-if="field.type === 'text'" 
                                 :field="field" 
                                 :store="store" 
                                 :data="address"
-                                :val="address[field.name]"
+                                :val="field.subfield ? address[field.name][field.subfield] : address[field.name]"
                                 @input="(event) => {
                                     state.addresses[index][field.name] = event.target.value;
                                 }"

--- a/resources/js/config/Pages/Orders/Form/_details.js
+++ b/resources/js/config/Pages/Orders/Form/_details.js
@@ -3,7 +3,7 @@ export default {
         general: {
             rows: [
                 {
-                    className: 'grid-cols-2 gap-4',
+                    className: 'grid-flow-col grid-cols-2 gap-4',
                     fields: [
                         {
                             name: 'type_of_transport',
@@ -14,54 +14,55 @@ export default {
                         },
                         {
                             name: 'order_status_id',
+                            className: 'col-1',
                             type: 'select',
                             options: "orderstatuses",
-                            displayKey: 'internal_name',
+                            displayKey: 'name',
                             match: "id",
-                            className: 'col-1',
+                            className: 'col-auto bg-red-400',
                             placeholder: 'pages.orders.form.order_status',
                             label: 'pages.orders.form.order_status',
                         },
                     ]
                 },
                 {
-                    className: 'grid-cols-4 gap-4',
+                    className: 'grid-flow-col grid-cols-2 gap-4',
                     fields: [
                         {
                             name: 'id',
                             subfield: 'partner',
-                            className: 'col-1',
                             type: 'select',
                             options: "partners",
                             displayKey: 'company_name',
                             match: "id",
                             placeholder: 'pages.orders.form.partner',
                             label: 'pages.orders.form.partner',
+                            className: "grid-flow-col bg-blue-400"
                         },
                         {
                             name: 'origin',
-                            className: 'col-1',
                             type: 'select',
                             options: "origins",
                             displayKey: 'title',
                             match: 'id',
                             placeholder: 'pages.orders.form.origin',
                             label: 'pages.orders.form.origin',
+                            className: "grid-flow-col bg-blue-400"
                         },
                         {
                             name: 'customer_reference',
-                            className: 'col-1',
                             type: 'text',
                             placeholder: 'pages.orders.form.customer_refernce',
                             label: 'pages.orders.form.customer_refernce',
+                            className: "grid-flow-col bg-blue-400"
                         },
                         {
                             name: "details",
                             subfield: 'distance_km',
-                            className: 'col-1',
                             type: 'text',
                             placeholder: 'pages.orders.form.distance_km',
                             label: 'pages.orders.form.distance_km',
+                            className: "grid-flow-col bg-blue-400"
                         },
                     ]
                 },
@@ -112,6 +113,16 @@ export default {
         parcels: {
             fields: [
                 {
+                    name: 'parcel_type',
+                    type: 'select',
+                    options: "packingtypes",
+                    displayKey: 'title',
+                    match: 'id',
+                    className: 'col-auto',
+                    placeholder: 'pages.orders.form.length',
+                    label: 'pages.orders.form.length',
+                },
+                {
                     name: 'length',
                     type: 'text',
                     keyName: 'id',
@@ -143,11 +154,12 @@ export default {
             ]
         },
         addresses: {
+            className: "grid-cols-3 gap-4",
             rows: [
                 {className: "", fields : [
                     {
                         name: 'address_type',
-                        type: 'text',
+                        type: 'badge_dd',
                         className: 'col-auto',
                         placeholder: 'pages.addresses.type',
                         label: 'pages.addresses.type',
@@ -157,12 +169,10 @@ export default {
                     {
                         name: 'first_name',
                         type: 'text',
-                        className: 'col-auto',
+                        className: 'col-span-2',
                         placeholder: 'pages.customers.form.first_name',
                         label: 'pages.customers.form.first_name',
                     },
-                ]},
-                {className: "", fields : [
                     {
                         name: 'last_name',
                         type: 'text',
@@ -186,7 +196,51 @@ export default {
                         placeholder: 'pages.customers.form.house_number',
                         label: 'pages.customers.form.house_number',
                     },
-                ]}
+                ]},
+                {className: "", fields : [
+                    {
+                        name: 'zip_code',
+                        type: 'text',
+                        className: 'col-span-2',
+                        placeholder: 'pages.customers.form.zip_code',
+                        label: 'pages.customers.form.zip_code',
+                    },
+                    {
+                        name: 'city',
+                        type: 'text',
+                        className: 'col-auto',
+                        placeholder: 'pages.customers.form.city',
+                        label: 'pages.customers.form.city',
+                    },
+                ]},
+                {className: "", fields : [
+                    {
+                        subfield: 'country_name',
+                        name: 'country',
+                        type: 'text',
+                        className: 'col-span-2',
+                        placeholder: 'pages.customers.form.country',
+                        label: 'pages.customers.form.country',
+                    }
+                ]},
+                {className: "", fields : [
+                    {
+                        name: 'phone',
+                        type: 'text',
+                        className: 'col-span-2',
+                        placeholder: 'pages.customers.form.phone',
+                        label: 'pages.customers.form.phone',
+                    },
+                ]},
+                {className: "", fields : [
+                    {
+                        name: 'email',
+                        type: 'text',
+                        className: 'col-auto',
+                        placeholder: 'pages.customers.form.email',
+                        label: 'pages.customers.form.email',
+                    },
+                ]},
             ],
         },
     }   

--- a/resources/js/lib/Data.js
+++ b/resources/js/lib/Data.js
@@ -13,6 +13,10 @@ export default class Data {
         let ratings = await axios.get('/api/ratings');
         return ratings;
     }
+    async #packingtypes(){
+        let packingtypes = await axios.get('/api/packingtypes');
+        return packingtypes;
+    }
     async #ism(){
         let ism = await axios.get('/api/invocie-shipping-methods');
         return ism;
@@ -59,6 +63,8 @@ export default class Data {
                 return await this.#origins();
             case 'ratings':
                 return await this.#ratings();
+            case 'packingtypes':
+                return await this.#packingtypes();
             case 'ism':
                 return await this.#ism();
             case 'invoicedispatch':

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -15,6 +15,16 @@
         "throttle": "Zu viele Anmeldeversuche. Bitte versuchen Sie es in :seconds Sekunden erneut."
     },
     "general": {
+        "packing_types": {
+            "box": "Karton",
+            "roll": "Rolle",
+            "bag": "Beutel",
+            "package": "Paket",
+            "envelope": "Umschlag",
+            "pallet": "Palette",
+            "bulky_good": "Sperrgut",
+            "other": "Sonstiges"
+        },
         "ratings": {
             "excellent": "Ausgezeichnet",
             "good": "Gut",

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,7 +45,7 @@ Route::middleware('auth:sanctum')->group(function(){
             ["id" => 5, "title" => "general.ratings.excellent", "rating" => 5]
         ];
     });
-    Route::get('/packing-types', function (Request $request){
+    Route::get('/packingtypes', function (Request $request){
         return [
             ["id" => 1, "title" => "general.packing_types.package"],
             ["id" => 2, "title" => "general.packing_types.pallet"],


### PR DESCRIPTION
- Added a new method `#packingtypes()` to fetch packing types from the API.
- Updated the grid layout and styles in the orders form.
- Removed the `col-1` class from some fields in the orders form.
- Added `col-auto bg-red-400` class to the order status field in the orders form.
- Added `grid-flow-col bg-blue-400` class to the partner and origin fields in the orders form.