### PR TITLE
🔧 fix: adjust layout and styling for address grid and copy address button

### DIFF
--- a/resources/js/Components/Page.vue
+++ b/resources/js/Components/Page.vue
@@ -58,7 +58,7 @@
             <ComplexTable :searchConfig="searchConfig" :metaData="metaData" :contentSettings="page.bodyContentSettings" :tableConfig="tableConfig" :content="content" />
         </div>
         <div v-else-if="page.preset === 'tabs'">
-            <TabContent :config="page" />
+            <TabContent :content="content" :config="page" />
         </div>
         <div v-else-if="page.preset === 'form'">
             <Form :content="content" :useData="page.mode === 'edit'" :store="store" :form="page.form" />

--- a/resources/js/Components/Tabs.vue
+++ b/resources/js/Components/Tabs.vue
@@ -19,8 +19,7 @@ onMounted(() => {
 
 </script>
 <template>
-    
-    <div class="mb-4 border-b border-gray-200 dark:border-gray-700">
+    <div class="grid justify-between grid-flow-col mb-4 border-b border-gray-200 dark:border-gray-700 place-items-center">
         <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="default-tab" data-tabs-toggle="#default-tab-content" role="tablist">
             <li v-for="tab in config.tabs" class="me-2" role="presentation">
                 <button class="grid grid-flow-col p-4 border-b-2 rounded-t-lg place-items-center" 
@@ -33,6 +32,9 @@ onMounted(() => {
                 {{ $t(tab.title) }}</button>
             </li>
         </ul>
+        <div class="grid grid-flow-col gap-4">
+            <button v-if="config.actions" v-for="action in config.actions" @click="action.handler(content)" class="p-2 px-4 text-white rounded-md bg-primary-700 hover:bg-primary-600" :class="action.class">{{ $t(action.title) }}</button>
+        </div>
     </div>
     <div id="default-tab-content" class="w-full">
         <div

--- a/resources/js/Pages/Orders/Parts/OrderEditDetails.vue
+++ b/resources/js/Pages/Orders/Parts/OrderEditDetails.vue
@@ -179,7 +179,6 @@
     
 </script>
 <template>
-    
     <div class="grid grid-flow-col grid-cols-4 gap-4 place-items-start">
         <div class="grid col-span-3 gap-8 px-4">
             <p class="mt-10 text-[16px] font-bold text-corporate-700">Auftragsdetails</p>
@@ -235,8 +234,8 @@
                     <p class="pt-2 mt-2 border-t"><a :href="'tel:' + content.customer?.headquarter?.phone">{{ content.customer?.headquarter?.phone }}</a></p>
                     <p><a :href="'mailto:' + content.customer?.headquarter?.email">{{ content.customer?.headquarter?.email }}</a></p>
                 </div>
-                <div class="grid max-w-full grid-flow-col gap-4 pb-4 overflow-x-scroll">
-                    <div v-for="address,ai in content.addresses" class="grid w-full gap-4 p-3 rounded-md bg-slate-50">
+                <div class="grid justify-start max-w-full grid-flow-col gap-4 pb-4 overflow-x-scroll">
+                    <div v-for="address,ai in content.addresses" class="grid w-full min-w-[380px] gap-4 p-3 rounded-md bg-slate-50">
                         <div v-for="row,ri in _config.sections.addresses.rows" :class="row.className">
                             <div v-for="field,fi in row.fields" :class="field.className">
                                 <div class="relative pt-8" v-if="field.type==='badge_dd'">
@@ -267,11 +266,11 @@
                             <button class="grid justify-start gap-2 place-items-center" @click="copyAddressToClipboard(address, ai)">
                                 <span class="grid justify-start grid-flow-col gap-2 text-green-500 place-items-center" v-if="copiedAddress === ai && feedback === true">
                                     <el-icon size="18"><Check /></el-icon>
-                                    <span>Addresse kopiert!</span>
+                                    <span>{{ $t('labels.general.messages.copied') }}</span>
                                 </span>
                                 <span class="grid justify-start grid-flow-col gap-2 place-items-center" v-else>
                                     <el-icon size="18"><DocumentCopy /></el-icon>
-                                    <span>Kopiere Adresse</span>
+                                    <span>{{ $t('labels.general.messages.copy') }}</span>
                                 </span>
                             </button>
                         </div>
@@ -283,60 +282,62 @@
             </div>
 
             <p class="mt-10 text-[16px] font-bold text-corporate-700">Packstücke</p>
-            <div class="grid gap-4">
-                <div v-for="parcel,index in state.parcels" :key="index" class="grid grid-flow-row gap-4" :class="parcel.className ?? 'grid-flow-row grid-cols-7'">
-                    <div class="grid justify-center w-6 place-items-center">
-                        <span class="grid font-bold text-corporate-700 text-1 place-items-center">{{index + 1}}</span>
+            <div class="grid grid-flow-row">
+                <div v-for="parcel,index in state.parcels" :key="index" class="inline-flex gap-4 mb-5">
+                    <div class="grid w-14 place-items-center">
+                        <span class="grid font-bold text-corporate-700 text-1 place-items-center text-[18px]">{{index + 1}}</span>
                     </div>
-                    <div v-for="field in _config.sections.parcels.fields" :class="field.className ?? 'grid-flow-col'">
-                        <BindableTextField 
-                            v-if="field.type === 'text'" 
-                            :field="field" 
-                            :store="store" 
-                            :data="parcel"
-                            :val="parcel[field.name]"
-                            @input="(event) => {
-                                state.parcels[index][field.name] = event.target.value;
-                            }"
-                            />
-                            
-                        <CheckboxField 
-                            v-else-if="field.type === 'check'" 
-                            :field="field" 
-                            :store="store" 
-                            :data="parcel" 
-                            />
-                            
-                        <SelectField 
-                            v-else-if="field.type === 'select'" 
-                            :field="field" 
-                            :store="store" 
-                            :data="parcel" 
-                            />
-                            
-                        <SearchableField 
-                            v-else-if="field.type === 'search'" 
-                            :field="field" 
-                            :store="store" 
-                            :data="parcel" 
-                            />
-                            
-                        <TextAreaField 
-                            v-else-if="field.type === 'input'" 
-                            :field="field" 
-                            :store="store" 
-                            :data="parcel" 
-                            />
-                    
+                    <div class="grid w-full grid-flow-col grid-cols-5 gap-3">
+                        <div v-for="field in _config.sections.parcels.fields" class="grid w-full">
+                            <BindableTextField 
+                                v-if="field.type === 'text'" 
+                                :field="field" 
+                                :store="store" 
+                                :data="parcel"
+                                :val="parcel[field.name]"
+                                @input="(event) => {
+                                    state.parcels[index][field.name] = event.target.value;
+                                }"
+                                />
+                                
+                            <CheckboxField 
+                                v-else-if="field.type === 'check'" 
+                                :field="field" 
+                                :store="store" 
+                                :data="parcel" 
+                                />
+                                
+                            <SelectField 
+                                v-else-if="field.type === 'select'" 
+                                :field="field" 
+                                :store="store" 
+                                :data="parcel" 
+                                />
+                                
+                            <SearchableField 
+                                v-else-if="field.type === 'search'" 
+                                :field="field" 
+                                :store="store" 
+                                :data="parcel" 
+                                />
+                                
+                            <TextAreaField 
+                                v-else-if="field.type === 'input'" 
+                                :field="field" 
+                                :store="store" 
+                                :data="parcel" 
+                                />
+                        
+                        </div>
                     </div>
-                    <div class="grid justify-end w-24 grid-flow-col gap-4 place-items-center">
+                    <div class="inline-flex gap-4">
                         <button @click="dup(parcel)" class="grid w-10 h-10 text-white transition-colors rounded-md hover:bg-primary-600 duration-200ms place-items-center bg-primary-700"><el-icon><CopyDocument /></el-icon></button>
                         <button @click="rem(index)" class="grid w-10 h-10 text-white transition-colors bg-red-700 rounded-md hover:bg-red-600 duration-200ms place-items-center"><el-icon><Delete /></el-icon></button>
                     </div>
                 </div>
                 <button @click="add()" class="grid grid-flow-col gap-2 p-2 mt-3 text-white transition-colors duration-200 rounded-md place-items-center place-self-end bg-primary-700 hover:bg-primary-600"><el-icon><Plus /></el-icon> {{ $t('buttons.general.add_parcel') }}</button>
                 
-                <div class="grid grid-flow-col gap-4 pt-4">
+                <div class="grid grid-flow-col gap-4 pt-4 mt-3">
                     <div class="grid grid-flow-col gap-2 p-2 rounded-md bg-slate-100">
                         <div class="grid rounded-md columns-auto w-14 h-14 bg-slate-200 place-items-center">
                             <img src="/images/svg/packages.svg" alt="Parcel Icon" class="w-10 h-10" />
@@ -409,22 +410,20 @@
                 </div>
                 <div class="">
                     <p class="font-semibold text-corporate-700">Leistungsdatum</p>
-                    <p>
-                        <div class="relative grid justify-end max-w-sm grid-flow-row">
-                            <input
-                            id="order_date_of_service_datepicker"
-                            datepicker
-                            datepicker-buttons
-                            datepicker-autoselect-today
-                            :datepicker-title="$t('select-date')"
-                            datepicker-format="DD.MM.YYYY"
-                            :value="content.month_and_year ?? null"
-                            type="text" 
-                            class="p-0 text-right bg-transparent border-0 appearance-none cursor-pointer focus:ring-0 focus:border-0 focus:outline-none"
-                            placeholder="Select date">
-                            <span class="cursor-pointer text-corporate-700" @click="content.month_and_year = moment().format('DD.MM.YYYY')">Leistung ist Heute</span>
-                        </div>
-                    </p>
+                    <div class="relative grid justify-end max-w-sm grid-flow-row place-items-end">
+                        <input
+                        id="order_date_of_service_datepicker"
+                        datepicker
+                        datepicker-buttons
+                        datepicker-autoselect-today
+                        :datepicker-title="$t('select-date')"
+                        datepicker-format="DD.MM.YYYY"
+                        :value="content.month_and_year ?? moment().format('DD.MM.YYYY')"
+                        type="text" 
+                        class="p-0 text-right bg-transparent border-0 appearance-none cursor-pointer focus:ring-0 focus:border-0 focus:outline-none"
+                        placeholder="Select date">
+                        <span class="cursor-pointer text-corporate-700" @click="content.month_and_year = moment().format('DD.MM.YYYY')">Leistung ist Heute</span>
+                    </div>
                 </div>
                 <div class="">
                     <p class="font-semibold text-corporate-700">Storniert</p>
@@ -462,10 +461,10 @@
                     <p :class="{'text-corporate-500': calcSummary() >= 0, 'text-red-700': calcSummary() < 0 }">{{ calcSummary() >= 0 ? "Gewinn" : "Verlust" }}</p>
                 </div>
             </div>
-            <div class="grid grid-flow-row gap-4 p-3 my-4 border rounded-md bg-slate-50">
+            <!-- <div class="grid grid-flow-row gap-4 p-3 my-4 border rounded-md bg-slate-50">
                 <button class="px-4 py-2 text-white rounded-md bg-primary-700 hover:bg-primary-600">Auftrag speichern</button>
                 <button :disabled="content.details.date_of_cancellation !== null && content.details.date_of_cancellation !== ''" class="px-4 py-2 text-red-700 rounded-md hover:text-red-800 disabled:text-slate-500 disabled:bg-transparent disabled:hover:text-slate-500">{{ $t('buttons.general.cancel_order') }}</button>
-            </div>
+            </div> -->
         </div>
     </div>
 </template>

--- a/resources/js/config/Pages/Orders/Form/_details.js
+++ b/resources/js/config/Pages/Orders/Form/_details.js
@@ -121,7 +121,7 @@ export default {
                     match: 'id',
                     className: 'col-auto',
                     placeholder: '',
-                    label: 'pages.orders.form.length',
+                    label: 'pages.orders.form.parcel_type',
                 },
                 {
                     name: 'length',

--- a/resources/js/config/Pages/Orders/_edit.js
+++ b/resources/js/config/Pages/Orders/_edit.js
@@ -11,6 +11,14 @@ export default {
     title: "",
     preset: "tabs",
     mode: "edit",
+    actions: [
+        {handler: (data) => {
+            alert(`Speichere Auftrag: ${(data?.order_number ?? data.data.order_number)}`)
+        }, class: "", title: "buttons.general.save"},
+        {handler: (data) => {
+            alert(`Storniere Auftrag: ${(data?.order_number ?? data.data.order_number)}`)
+        }, class: "bg-red-700 hover:bg-red-600", title: "buttons.general.void"},
+    ],
     tabs: [
         {
             "title": "pages.orders.tabs.details",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -178,7 +178,7 @@
                 "partner": "Partner",
                 "origin": "Herkunft",
                 "first_name": "Vorname",
-                "parcel_type": "Packstücktyp",
+                "parcel_type": "Packstück",
                 "length": "Länge (cm)",
                 "width": "Breite (cm)",
                 "height": "Höhe (cm)",
@@ -306,7 +306,7 @@
                 "order_number": "Auftragsnummer",
                 "forwarder": "Dienstleister",
                 "type_of_transport": "Transportart",
-                "origin": "Abholort",
+                "origin": "Herkunft",
                 "status": "Status",
                 "customer_reference": "Kundenreferenz",
                 "provision": "Provision",
@@ -422,7 +422,9 @@
             "download_label": "Versandlabel",
             "download_transport_details": "Transportauftrag",
             "messages": {
-                "changed_state_to": "hat den Status geändert zu"
+                "changed_state_to": "hat den Status geändert zu",
+                "copy": "Kopieren",
+                "copied": "Kopiert!"
             }
         },
         "filter": {


### PR DESCRIPTION
The grid layout for addresses is updated to justify-start and min-width set
for the address grid to ensure proper alignment and display of addresses.
The text for the copy address button is now dynamic based on language
translation keys to provide better user experience.