### PR TITLE
Forwarder seeder

### DIFF
--- a/app/Http/Requests/TmsForwarderRequest.php
+++ b/app/Http/Requests/TmsForwarderRequest.php
@@ -31,7 +31,6 @@ class TmsForwarderRequest extends FormRequest
      */
     public function forwarderRules()
     {
-
         return [
             'company_name' => ['required', 'string', 'max:200'],
             'internal_id' => ['required', 'string', 'max:100'],
@@ -41,7 +40,7 @@ class TmsForwarderRequest extends FormRequest
             'rating' => ['nullable', 'integer', 'min:1'],
             'forwarder_type' => ['nullable', 'integer'],
             'comments' => ['nullable', 'string'],
-            'url_logo' => ['nullable', 'url'],//https://upload.wikimedia.org/wikipedia/commons/thumb/b/b3/DHL_Express_logo.svg/2560px-DHL_Express_logo.svg.png
+            'url_logo' => ['nullable', 'string'],
             'legal_entity_type' => ['nullable', 'integer'],
         ];
     }

--- a/database/factories/TmsForwarderFactory.php
+++ b/database/factories/TmsForwarderFactory.php
@@ -24,10 +24,10 @@ class TmsForwarderFactory extends Factory
      * @var array
      */
     private array $logos = [
-        "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/United_Parcel_Service_logo_2014.svg/1718px-United_Parcel_Service_logo_2014.svg.png",
-        "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b3/DHL_Express_logo.svg/2560px-DHL_Express_logo.svg.png",
-        "https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/TNT_Logo.svg/2560px-TNT_Logo.svg.png",
-        "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/FedEx_Express.svg/1200px-FedEx_Express.svg.png"
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/United_Parcel_Service_logo_2014.svg/1718px-United_Parcel_Service_logo_2014.svg.png',
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b3/DHL_Express_logo.svg/2560px-DHL_Express_logo.svg.png',
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/TNT_Logo.svg/2560px-TNT_Logo.svg.png',
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/FedEx_Express.svg/1200px-FedEx_Express.svg.png'
     ];
 
     /**
@@ -48,7 +48,6 @@ class TmsForwarderFactory extends Factory
             'rating' => $this->faker->numberBetween(1, 5),
             'forwarder_type' => null,
             'comments' => $this->faker->sentence,
-            // 'url_logo' => $this->faker->imageUrl(),
             'url_logo' => $this->getRandomLogo(),
         ];
     }

--- a/database/factories/TmsForwarderFactory.php
+++ b/database/factories/TmsForwarderFactory.php
@@ -19,6 +19,18 @@ class TmsForwarderFactory extends Factory
     protected $model = TmsForwarder::class;
 
     /**
+     * These will be used to fake forwarder logo picture on the frontend.
+     *
+     * @var array
+     */
+    private array $logos = [
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/United_Parcel_Service_logo_2014.svg/1718px-United_Parcel_Service_logo_2014.svg.png",
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b3/DHL_Express_logo.svg/2560px-DHL_Express_logo.svg.png",
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/TNT_Logo.svg/2560px-TNT_Logo.svg.png",
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/FedEx_Express.svg/1200px-FedEx_Express.svg.png"
+    ];
+
+    /**
      * Define the model's default state.
      *
      * @return array<string, mixed>
@@ -42,13 +54,6 @@ class TmsForwarderFactory extends Factory
     }
 
     private function getRandomLogo(){
-        return Arr::random($this->LOGOS);
+        return Arr::random($this->logos);
     }
-
-    private $LOGOS = [
-        "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/United_Parcel_Service_logo_2014.svg/1718px-United_Parcel_Service_logo_2014.svg.png",
-        "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b3/DHL_Express_logo.svg/2560px-DHL_Express_logo.svg.png",
-        "https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/TNT_Logo.svg/2560px-TNT_Logo.svg.png",
-        "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/FedEx_Express.svg/1200px-FedEx_Express.svg.png"
-    ];
 }

--- a/database/seeders/TmsForwarderSeeder.php
+++ b/database/seeders/TmsForwarderSeeder.php
@@ -18,6 +18,7 @@ class TmsForwarderSeeder extends Seeder
             [
                 'company_name' => 'Emons',
                 'slug' => 'emons.forwarder',
+                'url_logo' => '/images/forwarder-logos/emons.svg',
             ]
         );
 
@@ -26,6 +27,7 @@ class TmsForwarderSeeder extends Seeder
             [
                 'company_name' => 'TimoCom',
                 'slug' => 'timocom.forwarder',
+                'url_logo' => '/images/forwarder-logos/timocom.svg',
             ]
         );
 

--- a/database/seeders/TmsForwarderSeeder.php
+++ b/database/seeders/TmsForwarderSeeder.php
@@ -31,7 +31,11 @@ class TmsForwarderSeeder extends Seeder
             ]
         );
 
-        //Create 18 random forwarders
-        TmsForwarder::factory()->count(config('constants.numberOfDbRecords') - 2)->create();
+        $environment = config('app.env');
+        if ($environment === 'local') {
+            //Create + 18 random forwarders, but only for local enviroment, not for production
+            TmsForwarder::factory()->count(config('constants.numberOfDbRecords') - 2)->create();
+        }
+        
     }
 }


### PR DESCRIPTION
From Patrick

Forwarder seeder: use the next two string as url for emons and timocom, during seeding. 

url_logo: emons => /images/forwarder-logos/emons.svg

url_logo: timocom => /images/forwarder-logos/timocom.svg

Also, change the url_logo validation from ‘url’ rule to ‘text’ rule.

Change forwarder seeder to have only 2 forwarders seeded: emons and timocom on production, but 20 on local.

Test seeding, when done.